### PR TITLE
Add line-number for emacs27

### DIFF
--- a/white-sand-theme.el
+++ b/white-sand-theme.el
@@ -236,7 +236,12 @@
         `(jde-java-font-lock-private-face ((t (:foreground ,keyword))))
         `(jde-java-font-lock-constant-face ((t (:foreground ,const))))
         `(jde-java-font-lock-modifier-face ((t (:foreground ,key3))))
-        `(jde-java-font-lock-number-face ((t (:foreground ,var))))))
+        `(jde-java-font-lock-number-face ((t (:foreground ,var))))
+        ;; emacs 27
+        ;; line number
+        `(line-number ((t (:background ,bg2 :foreground ,fg4))))
+        `(line-number-current-line ((t (:background ,bg2 :foreground ,fg1))))
+        ))
 
 ;;;###autoload
 (when load-file-name


### PR DESCRIPTION
HI,
Cool theme!

emacs27 has line-number built in. It is a replacement for hlinum. This is how it looks like:

![line-number](https://user-images.githubusercontent.com/3320432/106361411-06d93900-631e-11eb-8a5f-e18dfbaf5ec5.png)

(more or less... I'm further customising it externally and adding bold to the current line number face, because my font doesn't break emacs when used in bold)

best, /PA